### PR TITLE
Use `in` to support python3

### DIFF
--- a/import-kernel-symbols.py
+++ b/import-kernel-symbols.py
@@ -53,7 +53,7 @@ def main():
             m = re.match(symbols, line)
             addr = m.group(1)
             name = m.group(2)
-            if dictionary.has_key(name):
+            if name in dictionary:
                 imported.append("#define IMPORT_SYMBOL_VALUE_FOR_%s (0x%sUL)" % (name, addr))
     generated = header.replace('IMPORT_SYMBOL_PROLOGUE', template % '\n'.join(imported))
 


### PR DESCRIPTION
`has_key()` is removed in Python3.
Python 2.0-2 does not have `in` operator, but I think it's not the problem.